### PR TITLE
fix: revert PR #29 commit to maintain proper branching strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.2] - 2025-05-19
-
-### Changed
-- Maintenance release with dependency updates
-
 ## [0.6.1] - 2025-05-19
 
 ### Changed

--- a/dylan/utility_library/dylan_pr/dylan_pr_runner.py
+++ b/dylan/utility_library/dylan_pr/dylan_pr_runner.py
@@ -20,10 +20,7 @@ Python API usage:
 import sys
 from typing import Literal
 
-from rich.console import Console
-
 from ..provider_clis.provider_claude_code import get_provider
-from ..shared.progress import create_dylan_progress, create_task_with_dylan
 
 
 def run_claude_pr(
@@ -45,27 +42,18 @@ def run_claude_pr(
     # Determine output file based on format - always in tmp directory
     output_file = "tmp/pr_report.json" if output_format == "json" else "tmp/pr_report.md"
 
-    console = Console()
-
-    # Create progress bar
-    with create_dylan_progress(console) as progress:
-        task = create_task_with_dylan(progress, "Creating pull request...")
-
-        # Get provider and run the PR creation
-        provider = get_provider()
-        try:
-            result = provider.generate(
-                prompt, output_path=output_file, allowed_tools=allowed_tools, output_format=output_format
-            )
-            progress.update(task, completed=True)
-            console.print("\n✅ PR creation completed successfully")
-            console.print(f"📝 Report saved to: {output_file}")
-            if result:
-                console.print(result)
-        except Exception as e:
-            progress.update(task, completed=True)
-            console.print(f"\n❌ Error creating PR: {e}")
-            sys.exit(1)
+    # Get provider and run the PR creation
+    provider = get_provider()
+    try:
+        result = provider.generate(
+            prompt, output_path=output_file, allowed_tools=allowed_tools, output_format=output_format
+        )
+        print("Claude process completed successfully")
+        if result:
+            print(result)
+    except Exception as e:
+        print(f"Error running Claude: {e}")
+        sys.exit(1)
 
 
 def generate_pr_prompt(

--- a/dylan/utility_library/dylan_release/dylan_release_runner.py
+++ b/dylan/utility_library/dylan_release/dylan_release_runner.py
@@ -20,10 +20,7 @@ Python API usage:
 import sys
 from typing import Literal
 
-from rich.console import Console
-
 from ..provider_clis.provider_claude_code import get_provider
-from ..shared.progress import create_dylan_progress, create_task_with_dylan
 
 
 def run_claude_release(
@@ -45,30 +42,21 @@ def run_claude_release(
     # Determine output file based on format - always in tmp directory
     output_file = "tmp/release_report.json" if output_format == "json" else "tmp/release_report.md"
 
-    console = Console()
-
-    # Create progress bar
-    with create_dylan_progress(console) as progress:
-        task = create_task_with_dylan(progress, "Creating release...")
-
-        # Get provider and run the release
-        provider = get_provider()
-        try:
-            result = provider.generate(
-                prompt,
-                output_path=output_file,
-                allowed_tools=allowed_tools,
-                output_format=output_format
-            )
-            progress.update(task, completed=True)
-            console.print("\n✅ Release process completed successfully")
-            console.print(f"📝 Report saved to: {output_file}")
-            if result:
-                console.print(result)
-        except Exception as e:
-            progress.update(task, completed=True)
-            console.print(f"\n❌ Error running release: {e}")
-            sys.exit(1)
+    # Get provider and run the release
+    provider = get_provider()
+    try:
+        result = provider.generate(
+            prompt,
+            output_path=output_file,
+            allowed_tools=allowed_tools,
+            output_format=output_format
+        )
+        print("Claude process completed successfully")
+        if result:
+            print(result)
+    except Exception as e:
+        print(f"Error running Claude: {e}")
+        sys.exit(1)
 
 
 def generate_release_prompt(

--- a/dylan/utility_library/dylan_review/dylan_review_runner.py
+++ b/dylan/utility_library/dylan_review/dylan_review_runner.py
@@ -20,10 +20,7 @@ Python API usage:
 import sys
 from typing import Literal
 
-from rich.console import Console
-
 from ..provider_clis.provider_claude_code import get_provider
-from ..shared.progress import create_dylan_progress, create_task_with_dylan
 
 
 def run_claude_review(
@@ -47,30 +44,21 @@ def run_claude_review(
     # Determine output file based on format - always in tmp directory
     output_file = "tmp/review_report.json" if output_format == "json" else "tmp/review_report.md"
 
-    console = Console()
-
-    # Create progress bar
-    with create_dylan_progress(console) as progress:
-        task = create_task_with_dylan(progress, "Running code review...")
-
-        # Get provider and run the review
-        provider = get_provider()
-        try:
-            result = provider.generate(
-                prompt,
-                output_path=output_file,
-                allowed_tools=allowed_tools,
-                output_format=output_format
-            )
-            progress.update(task, completed=True)
-            console.print("\n✅ Review completed successfully")
-            console.print(f"📝 Report saved to: {output_file}")
-            if result:
-                console.print(result)
-        except Exception as e:
-            progress.update(task, completed=True)
-            console.print(f"\n❌ Error running review: {e}")
-            sys.exit(1)
+    # Get provider and run the review
+    provider = get_provider()
+    try:
+        result = provider.generate(
+            prompt,
+            output_path=output_file,
+            allowed_tools=allowed_tools,
+            output_format=output_format
+        )
+        print("Claude process completed successfully")
+        if result:
+            print(result)
+    except Exception as e:
+        print(f"Error running Claude: {e}")
+        sys.exit(1)
 
 
 def generate_review_prompt(branch: str | None = None, output_format: str = "text") -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claudecode-utility-library"
-version = "0.6.2"
+version = "0.6.1"
 description = "A utility package for Claude code generation"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -105,6 +105,7 @@ wheels = [
 
 [[package]]
 name = "claudecode-utility-library"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
This PR reverts the commit from PR #29 (7fda4523b954fbc5667faeec797ebdf71f826115) that was merged directly to main. This is part of our effort to maintain the proper develop → main branching strategy, where changes should go through develop first and only be merged to main during a release.