### PR TITLE
Add interactive mode for CLI verticals

### DIFF
--- a/dylan/utility_library/dylan_pr/dylan_pr_cli.py
+++ b/dylan/utility_library/dylan_pr/dylan_pr_cli.py
@@ -51,7 +51,7 @@ def pr(
         False,
         "--interactive",
         "-i",
-        help="Run in interactive chat mode with Claude.",
+        help="Run in interactive chat mode with Claude for PR creation.",
         show_default=True,
     )
 ):
@@ -88,8 +88,8 @@ def pr(
         "Target": target,
         "Changelog": format_boolean_option(not no_changelog, "✓ Enabled (default)", "✗ Disabled"),
         "Mode": "🔍 Dry run" if dry_run else "🚀 Live run",
-        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Debug": format_boolean_option(debug, "✓ Enabled", "✗ Disabled"),
+        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Exit": "Ctrl+C to interrupt"
     }))
     console.print()

--- a/dylan/utility_library/dylan_pr/dylan_pr_cli.py
+++ b/dylan/utility_library/dylan_pr/dylan_pr_cli.py
@@ -47,6 +47,13 @@ def pr(
         help="Print debug information (including the full prompt)",
         show_default=True,
     ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Run in interactive chat mode with Claude.",
+        show_default=True,
+    )
 ):
     """Create pull requests with AI-generated descriptions.
 
@@ -81,12 +88,14 @@ def pr(
         "Target": target,
         "Changelog": format_boolean_option(not no_changelog, "✓ Enabled (default)", "✗ Disabled"),
         "Mode": "🔍 Dry run" if dry_run else "🚀 Live run",
+        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Debug": format_boolean_option(debug, "✓ Enabled", "✗ Disabled"),
         "Exit": "Ctrl+C to interrupt"
     }))
     console.print()
 
     # Generate prompt - changelog is now enabled by default unless --no-changelog is specified
+    # For interactive mode, this will be the initial prompt sent to Claude.
     prompt = generate_pr_prompt(
         branch=branch,
         target_branch=target,
@@ -96,7 +105,13 @@ def pr(
     )
 
     # Run PR creation
-    run_claude_pr(prompt, allowed_tools=allowed_tools, output_format=output_format, debug=debug)
+    run_claude_pr(
+        prompt,
+        allowed_tools=allowed_tools,
+        output_format=output_format,
+        debug=debug,
+        interactive=interactive
+    )
 
 
 # For backwards compatibility and standalone usage

--- a/dylan/utility_library/dylan_pr/dylan_pr_runner.py
+++ b/dylan/utility_library/dylan_pr/dylan_pr_runner.py
@@ -65,48 +65,16 @@ def run_claude_pr(
     provider = get_provider()
 
     if interactive:
-        # Interactive mode - direct interaction, no progress spinner, different output handling
-        console.print(f"[{COLORS['info']}]Entering interactive PR session with Claude...[/]")
-        console.print(f"[{COLORS['muted']}]The generated PR prompt will be sent as initial input.[/]")
-        console.print(f"[{COLORS['muted']}]Type your messages directly to Claude below.[/]")
-        console.print(f"[{COLORS['muted']}]Use Claude's exit command or Ctrl+D to end the session.[/]")
-        console.print() # Add a newline for readability before Claude starts
-
-        try:
-            # In interactive mode, output_path is ignored by the provider.
-            # output_format might also be less relevant, but pass it along.
-            result = provider.generate(
-                prompt=prompt,
-                allowed_tools=allowed_tools,
-                output_format=output_format, # Less relevant for interactive but passed
-                interactive=True
-            )
-            # Result from interactive mode is typically a simple confirmation message.
-            console.print() # Add a newline after Claude session ends
-            console.print(create_status(result, "info")) # e.g., "Interactive session ended."
-            console.print(f"[{COLORS['muted']}]Interactive PR session concluded.[/]")
-
-        except KeyboardInterrupt:
-            console.print() # Newline after ^C
-            console.print(create_status("Interactive PR session terminated by user.", "warning"))
-            # No sys.exit(1) here, as user interruption is not necessarily an error state for the CLI itself.
-        except RuntimeError as e:
-            console.print()
-            console.print(create_status(str(e), "error"))
-            sys.exit(1)
-        except FileNotFoundError: # Should be caught by provider, but as a fallback
-            console.print()
-            console.print(create_status("Claude Code not found!", "error"))
-            console.print(f"\n[{COLORS['warning']}]Please install Claude Code:[/]")
-            console.print(f"[{COLORS['muted']}]  npm install -g {CLAUDE_CODE_NPM_PACKAGE}[/]")
-            console.print(f"\n[{COLORS['muted']}]For more info: {CLAUDE_CODE_REPO_URL}[/]")
-            sys.exit(1)
-        except Exception as e:
-            console.print()
-            console.print(create_status(f"Unexpected error during interactive session: {e}", "error"))
-            console.print(f"\n[{COLORS['muted']}]Please report this issue at:[/]")
-            console.print(f"[{COLORS['primary']}]{GITHUB_ISSUES_URL}[/]")
-            sys.exit(1)
+        # Use shared interactive session utility for consistent behavior
+        from ..shared.interactive.utils import run_interactive_session
+        result = run_interactive_session(
+            provider=provider,
+            prompt=prompt,
+            allowed_tools=allowed_tools,
+            output_format=output_format,
+            context_name="PR",
+            console=console
+        )
     else:
         # Non-interactive mode - use progress display and existing output handling
         with create_dylan_progress(console=console) as progress:

--- a/dylan/utility_library/dylan_pr/dylan_pr_runner.py
+++ b/dylan/utility_library/dylan_pr/dylan_pr_runner.py
@@ -35,6 +35,7 @@ def run_claude_pr(
     allowed_tools: list[str] | None = None,
     output_format: Literal["text", "json", "stream-json"] = "text",
     debug: bool = False,
+    interactive: bool = False,
 ) -> None:
     """Run Claude code with a PR creation prompt and specified tools.
 
@@ -43,6 +44,7 @@ def run_claude_pr(
         allowed_tools: List of allowed tools (defaults to Read, Bash, Write)
         output_format: Output format (text, json, stream-json)
         debug: Whether to print debug information (default False)
+        interactive: Whether to run in interactive mode (default False)
     """
     # Default safe tools for PR creation
     if allowed_tools is None:
@@ -59,45 +61,40 @@ def run_claude_pr(
     # tmp/dylan-pr-[current-branch]-to-[target].<extension>
     output_file = None
 
-    # Get provider and run the PR creation
+    # Get provider
     provider = get_provider()
 
-    with create_dylan_progress(console=console) as progress:
-        # Start the PR task
-        task = create_task_with_dylan(progress, "Dylan is creating your pull request...")
+    if interactive:
+        # Interactive mode - direct interaction, no progress spinner, different output handling
+        console.print(f"[{COLORS['info']}]Entering interactive PR session with Claude...[/]")
+        console.print(f"[{COLORS['muted']}]The generated PR prompt will be sent as initial input.[/]")
+        console.print(f"[{COLORS['muted']}]Type your messages directly to Claude below.[/]")
+        console.print(f"[{COLORS['muted']}]Use Claude's exit command or Ctrl+D to end the session.[/]")
+        console.print() # Add a newline for readability before Claude starts
 
         try:
+            # In interactive mode, output_path is ignored by the provider.
+            # output_format might also be less relevant, but pass it along.
             result = provider.generate(
-                prompt,
-                output_path=output_file,
+                prompt=prompt,
                 allowed_tools=allowed_tools,
-                output_format=output_format
+                output_format=output_format, # Less relevant for interactive but passed
+                interactive=True
             )
+            # Result from interactive mode is typically a simple confirmation message.
+            console.print() # Add a newline after Claude session ends
+            console.print(create_status(result, "info")) # e.g., "Interactive session ended."
+            console.print(f"[{COLORS['muted']}]Interactive PR session concluded.[/]")
 
-            # Update task to complete
-            progress.update(task, completed=True)
-
-            # Success message with flair
-            console.print()
-            console.print(create_status("Pull request created successfully!", "success"))
-            console.print(f"[{COLORS['muted']}]Report saved to tmp/ directory[/]")
-            console.print(f"[{COLORS['muted']}]Format: dylan-pr-<branch>-to-<target>.md[/]")
-            console.print()
-
-            # Show a nice completion message
-            console.print(f"[{COLORS['primary']}]{ARROW}[/] [bold]PR Summary[/bold] [{COLORS['accent']}]{SPARK}[/]")
-            console.print(f"[{COLORS['muted']}]Dylan has analyzed your commits and created a PR description.[/]")
-            console.print()
-
-            if result and "Mock" not in result:  # Don't show mock results
-                console.print(result)
+        except KeyboardInterrupt:
+            console.print() # Newline after ^C
+            console.print(create_status("Interactive PR session terminated by user.", "warning"))
+            # No sys.exit(1) here, as user interruption is not necessarily an error state for the CLI itself.
         except RuntimeError as e:
-            progress.update(task, completed=True)
             console.print()
             console.print(create_status(str(e), "error"))
             sys.exit(1)
-        except FileNotFoundError:
-            progress.update(task, completed=True)
+        except FileNotFoundError: # Should be caught by provider, but as a fallback
             console.print()
             console.print(create_status("Claude Code not found!", "error"))
             console.print(f"\n[{COLORS['warning']}]Please install Claude Code:[/]")
@@ -105,12 +102,59 @@ def run_claude_pr(
             console.print(f"\n[{COLORS['muted']}]For more info: {CLAUDE_CODE_REPO_URL}[/]")
             sys.exit(1)
         except Exception as e:
-            progress.update(task, completed=True)
             console.print()
-            console.print(create_status(f"Unexpected error: {e}", "error"))
+            console.print(create_status(f"Unexpected error during interactive session: {e}", "error"))
             console.print(f"\n[{COLORS['muted']}]Please report this issue at:[/]")
             console.print(f"[{COLORS['primary']}]{GITHUB_ISSUES_URL}[/]")
             sys.exit(1)
+    else:
+        # Non-interactive mode - use progress display and existing output handling
+        with create_dylan_progress(console=console) as progress:
+            task = create_task_with_dylan(progress, "Dylan is creating your pull request...")
+            try:
+                result = provider.generate(
+                    prompt,
+                    output_path=output_file, # output_file is None, provider handles filename
+                    allowed_tools=allowed_tools,
+                    output_format=output_format,
+                    interactive=False # Explicitly false
+                )
+                progress.update(task, completed=True)
+                console.print()
+                console.print(create_status("Pull request report generated successfully!", "success"))
+                console.print(f"[{COLORS['muted']}]Report saved to tmp/ directory[/]")
+                console.print(f"[{COLORS['muted']}]Format: dylan-pr-<branch>-to-<target>.md (or .json)[/]")
+                console.print()
+                console.print(f"[{COLORS['primary']}]{ARROW}[/] [bold]PR Report Summary[/bold] [{COLORS['accent']}]{SPARK}[/]")
+                console.print(f"[{COLORS['muted']}]Dylan has analyzed your commits and generated a PR report.[/]")
+                console.print()
+                if result and "Mock" not in result and "Authentication Error" not in result:
+                    console.print(result) # Display the report content if not a mock or auth error
+                elif "Authentication Error" in result:
+                    # The auth error from the provider is already well-formatted Markdown.
+                    console.print(result)
+
+
+            except RuntimeError as e:
+                progress.update(task, completed=True)
+                console.print()
+                console.print(create_status(str(e), "error"))
+                sys.exit(1)
+            except FileNotFoundError:
+                progress.update(task, completed=True)
+                console.print()
+                console.print(create_status("Claude Code not found!", "error"))
+                console.print(f"\n[{COLORS['warning']}]Please install Claude Code:[/]")
+                console.print(f"[{COLORS['muted']}]  npm install -g {CLAUDE_CODE_NPM_PACKAGE}[/]")
+                console.print(f"\n[{COLORS['muted']}]For more info: {CLAUDE_CODE_REPO_URL}[/]")
+                sys.exit(1)
+            except Exception as e:
+                progress.update(task, completed=True)
+                console.print()
+                console.print(create_status(f"Unexpected error: {e}", "error"))
+                console.print(f"\n[{COLORS['muted']}]Please report this issue at:[/]")
+                console.print(f"[{COLORS['primary']}]{GITHUB_ISSUES_URL}[/]")
+                sys.exit(1)
 
 
 def generate_pr_prompt(

--- a/dylan/utility_library/dylan_release/dylan_release_cli.py
+++ b/dylan/utility_library/dylan_release/dylan_release_cli.py
@@ -44,6 +44,13 @@ def release(
         help="Print debug information (including the full prompt)",
         show_default=True,
     ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Run in interactive chat mode with Claude for release management.",
+        show_default=True,
+    )
 ):
     """Create a new release with version bump and changelog update."""
     # Default values
@@ -70,12 +77,14 @@ def release(
         "Tag": format_boolean_option(tag, "✓ Create tag", "✗ No tag"),
         "Strategy": merge_strategy,
         "Mode": "🔍 Dry run" if dry_run else "⚠️ No git" if no_git else "🚀 Live run",
+        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Debug": format_boolean_option(debug, "✓ Enabled", "✗ Disabled"),
         "Exit": "Ctrl+C to interrupt"
     }))
     console.print()
 
     # Generate prompt
+    # For interactive mode, this will be the initial prompt sent to Claude.
     prompt = generate_release_prompt(
         bump_type=bump_type,
         create_tag=tag,
@@ -86,7 +95,13 @@ def release(
     )
 
     # Run release
-    run_claude_release(prompt, allowed_tools=allowed_tools, output_format=output_format, debug=debug)
+    run_claude_release(
+        prompt,
+        allowed_tools=allowed_tools,
+        output_format=output_format,
+        debug=debug,
+        interactive=interactive
+    )
 
 
 # For backwards compatibility and standalone usage

--- a/dylan/utility_library/dylan_release/dylan_release_cli.py
+++ b/dylan/utility_library/dylan_release/dylan_release_cli.py
@@ -77,8 +77,8 @@ def release(
         "Tag": format_boolean_option(tag, "✓ Create tag", "✗ No tag"),
         "Strategy": merge_strategy,
         "Mode": "🔍 Dry run" if dry_run else "⚠️ No git" if no_git else "🚀 Live run",
-        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Debug": format_boolean_option(debug, "✓ Enabled", "✗ Disabled"),
+        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Exit": "Ctrl+C to interrupt"
     }))
     console.print()

--- a/dylan/utility_library/dylan_release/dylan_release_runner.py
+++ b/dylan/utility_library/dylan_release/dylan_release_runner.py
@@ -64,44 +64,16 @@ def run_claude_release(
     provider = get_provider()
 
     if interactive:
-        # Interactive mode - direct interaction, no progress spinner, different output handling
-        console.print(f"[{COLORS['info']}]Entering interactive release management session with Claude...[/]")
-        console.print(f"[{COLORS['muted']}]The generated release prompt will be sent as initial input.[/]")
-        console.print(f"[{COLORS['muted']}]Type your messages directly to Claude below.[/]")
-        console.print(f"[{COLORS['muted']}]Use Claude's exit command or Ctrl+D to end the session.[/]")
-        console.print() # Add a newline for readability before Claude starts
-
-        try:
-            # In interactive mode, output_path is ignored by the provider.
-            result = provider.generate(
-                prompt=prompt,
-                allowed_tools=allowed_tools,
-                output_format=output_format, # Less relevant for interactive but passed
-                interactive=True
-            )
-            # Result from interactive mode is typically a simple confirmation message.
-            console.print() # Add a newline after Claude session ends
-            console.print(create_status(result, "info")) # e.g., "Interactive session ended."
-            console.print(f"[{COLORS['muted']}]Interactive release management session concluded.[/]")
-
-        except KeyboardInterrupt:
-            console.print() # Newline after ^C
-            console.print(create_status("Interactive release session terminated by user.", "warning"))
-            # No sys.exit(1) here, as user interruption is not necessarily an error state for the CLI itself.
-        except RuntimeError as e: # Catch errors from provider.generate()
-            console.print()
-            console.print(create_status(str(e), "error"))
-            sys.exit(1)
-        except FileNotFoundError: # Should be caught by provider, but as a fallback
-            console.print()
-            console.print(create_status("Claude Code not found!", "error")) # Match provider's message
-            # Consider adding CLAUDE_CODE_NPM_PACKAGE and CLAUDE_CODE_REPO_URL here if they are available
-            sys.exit(1)
-        except Exception as e: # Catch any other unexpected errors
-            console.print()
-            console.print(create_status(f"Unexpected error during interactive session: {e}", "error"))
-            # Consider adding GITHUB_ISSUES_URL here if available
-            sys.exit(1)
+        # Use shared interactive session utility for consistent behavior
+        from ..shared.interactive.utils import run_interactive_session
+        result = run_interactive_session(
+            provider=provider,
+            prompt=prompt,
+            allowed_tools=allowed_tools,
+            output_format=output_format,
+            context_name="release",
+            console=console
+        )
     else:
         # Non-interactive mode - use progress display and existing output handling
         with create_dylan_progress(console=console) as progress:

--- a/dylan/utility_library/dylan_review/dylan_review_cli.py
+++ b/dylan/utility_library/dylan_review/dylan_review_cli.py
@@ -62,8 +62,8 @@ def review(
     # Show review configuration
     console.print(create_box_header("Review Configuration", {
         "Branch": branch or "current branch",
-        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Debug": format_boolean_option(debug, "✓ Enabled", "✗ Disabled"),
+        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Exit": "Ctrl+C to interrupt"
     }))
     console.print()

--- a/dylan/utility_library/dylan_review/dylan_review_cli.py
+++ b/dylan/utility_library/dylan_review/dylan_review_cli.py
@@ -27,6 +27,13 @@ def review(
         help="Print debug information (including the full prompt)",
         show_default=True,
     ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Run in interactive chat mode with Claude for code review.",
+        show_default=True,
+    )
 ):
     """Run AI-powered code review using Claude Code.
 
@@ -55,20 +62,24 @@ def review(
     # Show review configuration
     console.print(create_box_header("Review Configuration", {
         "Branch": branch or "current branch",
+        "Interactive Mode": format_boolean_option(interactive, "✓ Enabled", "✗ Disabled"),
         "Debug": format_boolean_option(debug, "✓ Enabled", "✗ Disabled"),
         "Exit": "Ctrl+C to interrupt"
     }))
     console.print()
 
     # Generate prompt
+    # For interactive mode, this will be the initial prompt sent to Claude.
     prompt = generate_review_prompt(branch=branch, output_format=output_format)
 
     # Run review
     run_claude_review(
         prompt,
         allowed_tools=allowed_tools,
+        branch=branch, # Pass branch along, though runner might not use it directly with provider
         output_format=output_format,
-        debug=debug
+        debug=debug,
+        interactive=interactive
     )
 
 

--- a/dylan/utility_library/dylan_review/dylan_review_runner.py
+++ b/dylan/utility_library/dylan_review/dylan_review_runner.py
@@ -71,47 +71,16 @@ def run_claude_review(
     provider = get_provider()
 
     if interactive:
-        # Interactive mode - direct interaction, no progress spinner, different output handling
-        console.print(f"[{COLORS['info']}]Entering interactive code review session with Claude...[/]")
-        console.print(f"[{COLORS['muted']}]The generated review prompt will be sent as initial input.[/]")
-        console.print(f"[{COLORS['muted']}]Type your messages directly to Claude below.[/]")
-        console.print(f"[{COLORS['muted']}]Use Claude's exit command or Ctrl+D to end the session.[/]")
-        console.print() # Add a newline for readability before Claude starts
-
-        try:
-            # In interactive mode, output_path is ignored by the provider.
-            result = provider.generate(
-                prompt=prompt,
-                allowed_tools=allowed_tools,
-                output_format=output_format, # Less relevant for interactive but passed
-                interactive=True
-            )
-            # Result from interactive mode is typically a simple confirmation message.
-            console.print() # Add a newline after Claude session ends
-            console.print(create_status(result, "info")) # e.g., "Interactive session ended."
-            console.print(f"[{COLORS['muted']}]Interactive code review session concluded.[/]")
-
-        except KeyboardInterrupt:
-            console.print() # Newline after ^C
-            console.print(create_status("Interactive code review session terminated by user.", "warning"))
-            # No sys.exit(1) here, as user interruption is not necessarily an error state for the CLI itself.
-        except RuntimeError as e:
-            console.print()
-            console.print(create_status(str(e), "error"))
-            sys.exit(1)
-        except FileNotFoundError: # Should be caught by provider, but as a fallback
-            console.print()
-            console.print(create_status("Claude Code not found!", "error"))
-            console.print(f"\n[{COLORS['warning']}]Please install Claude Code:[/]")
-            console.print(f"[{COLORS['muted']}]  npm install -g {CLAUDE_CODE_NPM_PACKAGE}[/]")
-            console.print(f"\n[{COLORS['muted']}]For more info: {CLAUDE_CODE_REPO_URL}[/]")
-            sys.exit(1)
-        except Exception as e:
-            console.print()
-            console.print(create_status(f"Unexpected error during interactive session: {e}", "error"))
-            console.print(f"\n[{COLORS['muted']}]Please report this issue at:[/]")
-            console.print(f"[{COLORS['primary']}]{GITHUB_ISSUES_URL}[/]")
-            sys.exit(1)
+        # Use shared interactive session utility for consistent behavior
+        from ..shared.interactive.utils import run_interactive_session
+        result = run_interactive_session(
+            provider=provider,
+            prompt=prompt,
+            allowed_tools=allowed_tools,
+            output_format=output_format,
+            context_name="review",
+            console=console
+        )
     else:
         # Non-interactive mode - use progress display and existing output handling
         with create_dylan_progress(console=console) as progress:

--- a/dylan/utility_library/provider_clis/provider_claude_code.py
+++ b/dylan/utility_library/provider_clis/provider_claude_code.py
@@ -85,20 +85,31 @@ IMPORTANT: Generate the full report and save it directly to the file {output_pat
 
     def _build_command(
         self,
-        prompt: str,
+        prompt: str | None = None,  # Prompt is optional for interactive mode
         output_format: str = "text",
         allowed_tools: list[str] | None = None,
+        interactive: bool = False,
     ) -> list[str]:
         """Build the command to run Claude Code CLI.
 
         Args:
-            prompt: The prompt to send to the provider
-            output_format: Output format (text, json, stream-json)
+            prompt: The prompt to send to the provider (for non-interactive)
+            output_format: Output format (text, json, stream-json) (for non-interactive)
             allowed_tools: Optional list of allowed tools
+            interactive: Whether to build command for interactive mode
 
         Returns:
             Command as list of strings
         """
+        if interactive:
+            cmd = [self._BIN]
+            if allowed_tools:
+                cmd.extend(["--allowedTools"] + allowed_tools)
+            return cmd
+
+        # Non-interactive mode
+        if prompt is None:
+            raise ValueError("Prompt cannot be None for non-interactive mode.")
         cmd = [self._BIN, "-p", prompt]
 
         # Add output format if not text
@@ -152,6 +163,7 @@ IMPORTANT: Generate the full report and save it directly to the file {output_pat
         timeout: int | None = None,
         stream: bool = False,
         exit_command: str | None = DEFAULT_EXIT_COMMAND,
+        interactive: bool = False,
     ) -> str:
         """Generate content using Claude Code with proper interrupt handling.
 
@@ -160,9 +172,10 @@ IMPORTANT: Generate the full report and save it directly to the file {output_pat
             output_path: Optional path to save output to (will be added to prompt)
             allowed_tools: Optional list of allowed tools
             output_format: Output format (text, json, stream-json)
-            timeout: Optional timeout in seconds
-            stream: Whether to stream output (for interactive use)
-            exit_command: Custom command to gracefully exit (e.g., "/exit" or "/quit")
+            timeout: Optional timeout in seconds (for non-interactive mode)
+            stream: Whether to stream output (for non-interactive use)
+            exit_command: Custom command to gracefully exit (for non-interactive mode)
+            interactive: Whether to run in interactive mode
 
         Returns:
             The generated content or confirmation message
@@ -171,76 +184,102 @@ IMPORTANT: Generate the full report and save it directly to the file {output_pat
             RuntimeError: If Claude Code CLI is not found or returns an error
             KeyboardInterrupt: If the process is interrupted
         """
-        # Check if Claude is available and display appropriate message
+        # Check if Claude is available
         if not self._BIN or self._BIN == "claude":
             claude_path = shutil.which("claude")
             if not claude_path:
                 raise RuntimeError(CLAUDE_CODE_NOT_FOUND_MSG)
 
-        # Determine authentication method
-        is_using_api_key = "CLAUDE_API_KEY" in os.environ
-
-        # Prepare prompt and command
-        prepared_prompt = self._prepare_prompt(prompt, output_path)
-        cmd = self._build_command(prepared_prompt, output_format, allowed_tools)
-
-        # Show authentication method in use
-        if is_using_api_key:
-            print("Using Claude API key for authentication...", file=sys.stderr)
+        if interactive:
+            print("Entering interactive Claude session...", file=sys.stderr)
+            # output_path, output_format, timeout, stream, exit_command are ignored in interactive mode
+            # _prepare_prompt is also skipped
+            cmd = self._build_command(
+                prompt=None,  # Prompt is not part of the command itself for interactive
+                allowed_tools=allowed_tools,
+                interactive=True,
+            )
+            try:
+                process_input = prompt.encode() if prompt else None
+                # For interactive mode, claude takes over stdin/stdout/stderr
+                # We send the initial prompt (if any) via stdin.
+                result = subprocess.run(cmd, input=process_input) # No check=True, handle return code manually
+                
+                if result.returncode != 0:
+                    # Users can exit claude with Ctrl+D (EOF) which might result in a non-zero code.
+                    # Or they might use a command like /quit.
+                    # We don't want to raise an error for normal interactive exits.
+                    # However, if claude crashes, this might indicate an issue.
+                    # For now, we'll just print a message if returncode is non-zero.
+                    print(f"Claude interactive session exited with code {result.returncode}.", file=sys.stderr)
+                return "Interactive session ended."
+            except KeyboardInterrupt:
+                # subprocess.run handles SIGINT by terminating the child and then re-raising.
+                print("\nInteractive Claude session terminated by user.", file=sys.stderr)
+                # No need to manually terminate proc, subprocess.run does this.
+                raise # Re-raise KeyboardInterrupt
+            except FileNotFoundError as exc: # Should be caught by the check above, but as a safeguard
+                raise RuntimeError(
+                    f"Claude Code CLI not found. Install with:\n  {CLAUDE_CODE_INSTALL_CMD}"
+                ) from exc
+            except Exception as e: # Catch any other unexpected errors during interactive session
+                raise RuntimeError(f"Error during interactive Claude session: {e}") from e
         else:
-            print("Using Claude Code Max subscription...", file=sys.stderr)
+            # Existing non-interactive logic
+            is_using_api_key = "CLAUDE_API_KEY" in os.environ
 
-        try:
-            # Use Popen instead of run for better control over the process
-            with subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                bufsize=1,  # Line buffered
-            ) as proc:
-                output_lines = []
-                # Set up exit command listener but only in streaming mode
-                # In non-streaming mode, users should use Ctrl+C to interrupt
-                from ..shared.exit_command import setup_exit_command_handler
-                exit_triggered = setup_exit_command_handler(proc, exit_command if stream else None)
+            prepared_prompt = self._prepare_prompt(prompt, output_path)
+            cmd = self._build_command(
+                prepared_prompt, output_format, allowed_tools, interactive=False
+            )
 
-                try:
-                    # Stream output if requested, otherwise collect all lines
-                    if stream:
-                        for line in stream_process_output(proc, timeout, None):  # No exit command here, already set up
-                            print(line)
-                            output_lines.append(line)
-                            if exit_triggered.is_set():
-                                break
-                    else:
-                        # For non-streaming mode, still use a loop to check exit_triggered
-                        if proc.stdout:
-                            for line in proc.stdout:
-                                output_lines.append(line.strip())
+            if is_using_api_key:
+                print("Using Claude API key for authentication...", file=sys.stderr)
+            else:
+                print("Using Claude Code Max subscription...", file=sys.stderr)
+
+            try:
+                with subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    bufsize=1,  # Line buffered
+                ) as proc:
+                    output_lines = []
+                    from ..shared.exit_command import setup_exit_command_handler
+                    exit_triggered = setup_exit_command_handler(proc, exit_command if stream else None)
+
+                    try:
+                        if stream:
+                            for line in stream_process_output(proc, timeout, None):
+                                print(line)
+                                output_lines.append(line)
                                 if exit_triggered.is_set():
                                     break
+                        else:
+                            if proc.stdout:
+                                for line in proc.stdout:
+                                    output_lines.append(line.strip())
+                                    if exit_triggered.is_set():
+                                        break
+                    except TimeoutError as e:
+                        terminate_process(proc)
+                        raise RuntimeError(f"Claude Code process timed out after {timeout} seconds") from e
 
-                except TimeoutError as e:
-                    terminate_process(proc)
-                    raise RuntimeError(f"Claude Code process timed out after {timeout} seconds") from e
+                    return_code = proc.wait()
+                    stderr_output = proc.stderr.read() if proc.stderr else ""
+                    return self._handle_process_result(return_code, output_lines, stderr_output)
 
-                # Wait for the process to complete and check return code
-                return_code = proc.wait()
-                stderr = proc.stderr.read() if proc.stderr else ""
-
-                # Handle return code and produce final output
-                return self._handle_process_result(return_code, output_lines, stderr)
-
-        except FileNotFoundError as exc:
-            raise RuntimeError(
-                f"Claude Code CLI not found. Install with:\n  {CLAUDE_CODE_INSTALL_CMD}"
-            ) from exc
-        except subprocess.CalledProcessError as exc:
-            error_msg = exc.stderr or str(exc)
-            if "CLAUDE_API_KEY" not in os.environ:
-                return self._handle_auth_error(error_msg)
-            raise RuntimeError(f"Claude Code returned non-zero exit:\n{error_msg}") from exc
+            except FileNotFoundError as exc:
+                raise RuntimeError(
+                    f"Claude Code CLI not found. Install with:\n  {CLAUDE_CODE_INSTALL_CMD}"
+                ) from exc
+            except subprocess.CalledProcessError as exc: # Should be less likely with Popen
+                error_msg = exc.stderr or str(exc)
+                if "CLAUDE_API_KEY" not in os.environ:
+                    return self._handle_auth_error(error_msg)
+                raise RuntimeError(f"Claude Code returned non-zero exit:\n{error_msg}") from exc
 
     def _handle_auth_error(self, error_msg: str) -> str:
         """Handle authentication errors with helpful suggestions."""

--- a/dylan/utility_library/shared/interactive/__init__.py
+++ b/dylan/utility_library/shared/interactive/__init__.py
@@ -1,0 +1,1 @@
+"""Interactive mode utilities for Dylan CLI commands."""

--- a/dylan/utility_library/shared/interactive/utils.py
+++ b/dylan/utility_library/shared/interactive/utils.py
@@ -1,0 +1,79 @@
+"""Interactive session utilities for Claude interactions.
+
+Shared utilities for running interactive sessions with the Claude provider.
+"""
+
+import sys
+
+from rich.console import Console
+
+from ..config import (
+    CLAUDE_CODE_NPM_PACKAGE,
+    CLAUDE_CODE_REPO_URL,
+    GITHUB_ISSUES_URL,
+)
+from ..ui_theme import COLORS, create_status
+
+
+def run_interactive_session(
+    provider,
+    prompt,
+    allowed_tools,
+    output_format,
+    context_name="session",
+    console=None,
+):
+    """Run an interactive session with the provider.
+
+    Args:
+        provider: The provider instance
+        prompt: The initial prompt to send
+        allowed_tools: List of allowed tools
+        output_format: Output format
+        context_name: Context-specific name (e.g., "PR", "release", "review")
+        console: Rich console instance
+
+    Returns:
+        Result message from the session
+    """
+    if console is None:
+        console = Console()
+
+    console.print(f"[{COLORS['info']}]Entering interactive {context_name} session with Claude...[/]")
+    console.print(f"[{COLORS['muted']}]The generated prompt will be sent as initial input.[/]")
+    console.print(f"[{COLORS['muted']}]Type your messages directly to Claude below.[/]")
+    console.print(f"[{COLORS['muted']}]Use Claude's exit command or Ctrl+D to end the session.[/]")
+    console.print()
+
+    try:
+        result = provider.generate(
+            prompt=prompt,
+            allowed_tools=allowed_tools,
+            output_format=output_format,
+            interactive=True
+        )
+        console.print()
+        console.print(create_status(result, "info"))
+        console.print(f"[{COLORS['muted']}]Interactive {context_name} session concluded.[/]")
+        return result
+    except KeyboardInterrupt:
+        console.print()
+        console.print(create_status(f"Interactive {context_name} session terminated by user.", "warning"))
+        return f"Interactive {context_name} session terminated by user."
+    except RuntimeError as e:
+        console.print()
+        console.print(create_status(str(e), "error"))
+        sys.exit(1)
+    except FileNotFoundError:
+        console.print()
+        console.print(create_status("Claude Code not found!", "error"))
+        console.print(f"\n[{COLORS['warning']}]Please install Claude Code:[/]")
+        console.print(f"[{COLORS['muted']}]  npm install -g {CLAUDE_CODE_NPM_PACKAGE}[/]")
+        console.print(f"\n[{COLORS['muted']}]For more info: {CLAUDE_CODE_REPO_URL}[/]")
+        sys.exit(1)
+    except Exception as e:
+        console.print()
+        console.print(create_status(f"Unexpected error during interactive session: {e}", "error"))
+        console.print(f"\n[{COLORS['muted']}]Please report this issue at:[/]")
+        console.print(f"[{COLORS['primary']}]{GITHUB_ISSUES_URL}[/]")
+        sys.exit(1)

--- a/interactive_mode_feature_docs.md
+++ b/interactive_mode_feature_docs.md
@@ -1,0 +1,64 @@
+## Using the Interactive Mode (`--interactive` / `-i`)
+
+The `--interactive` (or `-i`) flag transforms the behavior of supported Dylan CLI commands (`pr`, `review`, `release`). Instead of executing a predefined task based on a prompt and then exiting, this flag launches an interactive chat session directly with the underlying AI model (Claude). The command's standard generated prompt (e.g., for PR generation, code review, or release management) is used to provide the initial context for this conversation.
+
+This mode allows for a more dynamic and conversational exchange. You can ask follow-up questions, request clarifications, provide further instructions, guide the AI's focus, or work through complex tasks step-by-step. It's particularly useful when the standard one-shot command execution might not be sufficient or when you want to explore options with AI assistance.
+
+### `dylan pr --interactive`
+
+The interactive mode for `dylan pr` allows for a conversational approach to creating and refining pull request descriptions.
+
+**Example:**
+```bash
+dylan pr --interactive
+```
+Or, for a specific branch:
+```bash
+dylan pr my-feature-branch --target main --interactive
+```
+
+**Use Cases:**
+*   **Refine PR Description:** After Claude generates an initial PR description based on the commits, you can ask it to rephrase sections, elaborate on certain points, or change the tone.
+*   **Discuss Changes:** Ask Claude about specific changes in the commit history and how they might be best presented.
+*   **Iterative Content Generation:** Work with Claude to build the PR description section by section.
+*   **Related Tasks:** Request Claude to perform related tasks, such as summarizing the technical debt addressed or suggesting areas for future improvement based on the current changes.
+
+### `dylan review --interactive`
+
+For `dylan review`, the interactive mode enables a dynamic code review session where you can delve deeper into the AI's feedback.
+
+**Example:**
+```bash
+dylan review --interactive
+```
+Or, to review a specific branch:
+```bash
+dylan review feature/my-bug-fix --interactive
+```
+
+**Use Cases:**
+*   **Clarify Review Comments:** If a suggestion from Claude is unclear, you can ask for more details or examples.
+*   **Explore Alternatives:** Request alternative solutions or approaches to issues identified by the AI.
+*   **Guide Focus:** Direct Claude to pay closer attention to specific files, functions, or aspects of the code (e.g., "Focus on potential security issues in `auth.py`").
+*   **Discuss Trade-offs:** Engage in a conversation about the trade-offs of different implementation choices.
+*   **Iterative Review:** Work through the review feedback item by item, discussing each point with Claude.
+
+### `dylan release --interactive`
+
+Interactive mode for `dylan release` provides a way to manage the release process conversationally, offering more control and oversight.
+
+**Example:**
+```bash
+dylan release --bump minor --interactive
+```
+Or, for a dry run:
+```bash
+dylan release --bump patch --mode dry-run --interactive
+```
+
+**Use Cases:**
+*   **Discuss Release Plan:** Before Claude executes steps like version bumping or changelog updates, you can discuss the plan and confirm details.
+*   **Step-by-Step Execution:** Ask Claude to perform release tasks one by one, allowing you to verify each step.
+*   **Troubleshoot Issues:** If an issue arises (e.g., a problem with version detection or changelog formatting), you can work with Claude interactively to diagnose and attempt to resolve it.
+*   **Confirm Actions:** Have Claude confirm critical actions (like tagging or pushing changes) before they are performed, if not already part of its standard interactive flow.
+*   **Custom Requests:** Ask for specific checks or information related to the release that might not be part of the standard prompt (e.g., "List all commits since the last tag before you proceed").

--- a/uv.lock
+++ b/uv.lock
@@ -212,7 +212,7 @@ wheels = [
 
 [[package]]
 name = "dylan"
-version = "0.6.8"
+version = "0.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary
Adds a new interactive mode feature to the CLI verticals (PR, Review, Release) that allows users to have conversational sessions with Claude.

## Changes
- Implemented `--interactive` / `-i` flag for all major CLI commands
- Created shared utility module for consistent interactive session handling
- Refactored CLI runners to support interactive mode
- Added documentation for the interactive mode feature

## Commits
- 20fd9a0: refactor(interactive): create shared utility for interactive Claude sessions
- b529c50: feat: Implement --interactive mode for CLI verticals

## Files Changed
### Core functionality
- dylan/utility_library/shared/interactive/__init__.py
- dylan/utility_library/shared/interactive/utils.py

### CLI Integration
- dylan/utility_library/dylan_pr/dylan_pr_cli.py
- dylan/utility_library/dylan_pr/dylan_pr_runner.py
- dylan/utility_library/dylan_release/dylan_release_cli.py
- dylan/utility_library/dylan_release/dylan_release_runner.py
- dylan/utility_library/dylan_review/dylan_review_cli.py
- dylan/utility_library/dylan_review/dylan_review_runner.py
- dylan/utility_library/provider_clis/provider_claude_code.py

### Documentation
- interactive_mode_feature_docs.md

## Testing Notes
1. Test creating a PR in interactive mode: `dylan pr --interactive`
2. Test running a review in interactive mode: `dylan review --interactive`
3. Test running a release in interactive mode: `dylan release --interactive`
4. Verify proper error handling when interrupting an interactive session

## Breaking Changes
None

<details>
<summary>Suggested Changelog Updates</summary>

### Added
- Added interactive mode (`--interactive`/`-i` flag) for all CLI commands that enables conversational sessions with Claude
- Created shared utilities for handling interactive Claude sessions
- Added comprehensive documentation explaining interactive mode usage and examples

### Changed
- Refactored CLI runners to incorporate interactive session support
- Enhanced Claude provider interface to handle both one-shot and interactive modes

</details>