### PR TITLE
docs: add prp for removing archon mentions from documentation

### DIFF
--- a/PRPs/features/completed/remove-archon-mentions.md
+++ b/PRPs/features/completed/remove-archon-mentions.md
@@ -1,0 +1,248 @@
+# Feature: Remove Archon Mentions from Documentation
+
+## Feature Description
+
+Remove all mentions of "archon" and "archin" from the project README and documentation files to maintain clean, focused project documentation. This is a documentation cleanup task to ensure no legacy or test content remains in production documentation.
+
+## User Story
+
+As a project maintainer
+I want to remove all mentions of "archon" or "archin" from the project documentation
+So that the documentation remains clean, professional, and focused on the actual project content
+
+## Problem Statement
+
+Historical commits show that test content mentioning "archon" was previously added to the README (commit fefd8fb: "hello from archon"). While this content appears to have been removed, we need to verify complete removal across all documentation files and ensure no similar mentions exist in other README files throughout the project.
+
+## Solution Statement
+
+Perform a comprehensive audit of all documentation files (README.md files at all levels) to identify and remove any mentions of "archon" or "archin". The solution will:
+
+1. Search all documentation files for case-insensitive matches
+2. Verify the main README.md is clean
+3. Check all subdirectory README files
+4. Document findings and confirm complete removal
+5. Provide validation that no mentions remain
+
+## Relevant Files
+
+### Primary Documentation File
+
+- `README.md` (lines 1-153) - Main project README file
+  - Currently clean (verified) - no archon mentions present
+  - This is the primary file that had historical archon content
+
+### Secondary Documentation Files to Verify
+
+- `concept_library/README.md` - Concept library documentation
+  - Needs verification for archon mentions
+- `concept_library/automated_bug_triage/README.md` - Bug triage docs
+  - Needs verification for archon mentions
+- `concept_library/cc_PRP_flow/README.md` - PRP flow documentation
+  - Needs verification for archon mentions
+- `concept_library/commit_hooks/README.md` - Commit hooks documentation
+  - Needs verification for archon mentions
+- `concept_library/full_review_loop/README.md` - Review loop documentation
+  - Needs verification for archon mentions
+- `concept_library/simple_dev/README.md` - Simple dev documentation
+  - Needs verification for archon mentions
+- `concept_library/simple_pr/README.md` - Simple PR documentation
+  - Needs verification for archon mentions
+- `concept_library/simple_review/README.md` - Simple review documentation
+  - Needs verification for archon mentions
+- `concept_library/simple_validator/README.md` - Simple validator documentation
+  - Needs verification for archon mentions
+- `dylan/utility_library/dylan_dev/README.md` - Dylan dev utility docs
+  - Needs verification for archon mentions
+- `dylan/utility_library/dylan_pr/README.md` - Dylan PR utility docs
+  - Needs verification for archon mentions
+- `dylan/utility_library/dylan_release/README.md` - Dylan release utility docs
+  - Needs verification for archon mentions
+- `dylan/utility_library/dylan_review/README.md` - Dylan review utility docs
+  - Needs verification for archon mentions
+- `dylan/utility_library/dylan_standup/README.md` - Dylan standup utility docs
+  - Needs verification for archon mentions
+
+### New Files
+
+No new files need to be created for this documentation cleanup task.
+
+## Relevant research docstring
+
+This is a documentation cleanup task that requires:
+
+- Git command line tools for searching history
+- Grep/search tools for pattern matching
+- Basic file editing capabilities
+
+Reference materials:
+
+- [Git grep documentation](https://git-scm.com/docs/git-grep)
+  - Used for searching across all tracked files
+  - Case-insensitive search: `git grep -i "pattern"`
+- [Grep with word boundaries](https://www.gnu.org/software/grep/manual/grep.html)
+  - Word boundary matching: `\b` for exact word matches
+  - Prevents false positives like "searching" matching "archin"
+
+## Implementation Plan
+
+### Phase 1: Comprehensive Audit
+
+Perform a thorough search across all documentation files to identify any remaining mentions of "archon" or "archin". This includes:
+- Using word-boundary grep to avoid false positives
+- Checking all README files at all directory levels
+- Verifying git history doesn't contain any missed instances
+
+### Phase 2: Verification and Documentation
+
+Verify that the main README.md and all subdirectory documentation files are clean. Document findings:
+- Confirm which files have been checked
+- Report any instances found and removed
+- Provide evidence of complete cleanup
+
+### Phase 3: Validation
+
+Validate that no mentions remain through automated checks and manual verification.
+
+## Step by Step Tasks
+
+### 1. Perform comprehensive search for archon/archin mentions
+
+- Use grep with word boundaries to search all README files: `grep -i "\barchon\b\|\barchin\b" README.md **/README.md`
+- Search all tracked files excluding .git directory: `git grep -i "\barchon\b\|\barchin\b"`
+- Document all findings with file paths and line numbers
+
+### 2. Verify main README.md is clean
+
+- Read the main README.md file completely
+- Confirm no mentions of "archon" or "archin" exist
+- Document confirmation in findings report
+
+### 3. Check all subdirectory README files
+
+- Read each README file in concept_library/ subdirectories
+- Read each README file in dylan/utility_library/ subdirectories
+- Confirm no mentions exist in any documentation files
+- Document findings for each file checked
+
+### 4. Remove any found mentions
+
+- If any mentions are found, use Edit tool to remove them
+- Preserve document structure and formatting
+- Ensure removal doesn't break markdown formatting or links
+- Document each edit made
+
+### 5. Create verification report
+
+- Create a summary report documenting:
+  - Total files checked
+  - Any mentions found and removed
+  - Confirmation that all documentation is now clean
+- Include search commands used for future reference
+
+### 6. Run validation commands
+
+- Execute all validation commands listed below
+- Confirm zero matches for archon/archin patterns
+- Document validation results
+
+## Testing Strategy
+
+See `CLAUDE.md` for complete testing requirements. This is a documentation-only change, so code tests are not required.
+
+### Verification Tests
+
+- Search validation: Confirm grep searches return zero matches
+- Visual inspection: Manually verify key documentation files are clean
+- Git diff: Verify any changes made are appropriate and complete
+
+### Edge Cases
+
+- False positives: Ensure searches don't match partial words (e.g., "searching" contains "archin")
+- Case sensitivity: Check both lowercase and uppercase variations
+- Hidden files: Ensure search includes all documentation, not just visible files
+- Git history: While we can't change history, document historical mentions for awareness
+
+## Acceptance Criteria
+
+- [ ] Main README.md contains no mentions of "archon" or "archin"
+- [ ] All subdirectory README files contain no mentions of "archon" or "archin"
+- [ ] Grep search with word boundaries returns zero matches across all documentation
+- [ ] Git grep returns zero matches in tracked files
+- [ ] Any removed content is documented with before/after context
+- [ ] Verification report is created documenting the cleanup
+- [ ] All markdown formatting remains valid after any edits
+
+## Validation Commands
+
+Execute every command to validate the feature works correctly with zero regressions.
+
+**Documentation verification commands:**
+
+```bash
+# Search all README files with word boundaries (should return no matches)
+grep -i "\barchon\b\|\barchin\b" README.md */README.md */*/README.md
+
+# Search all tracked files (should return no matches)
+git grep -i "\barchon\b\|\barchin\b" -- '*.md' '*.py' '*.txt'
+
+# Search case-insensitive without word boundaries to catch any edge cases
+git grep -i "archon\|archin" -- '*.md'
+
+# Verify main README specifically
+grep -i "archon\|archin" README.md
+echo "Exit code should be 1 (no matches): $?"
+
+# Check for any variations in casing
+git grep -i "ARCHON\|Archon\|archin\|Archin\|ARCHIN" -- '*.md'
+```
+
+**Markdown validation (if any edits were made):**
+
+```bash
+# If markdown-lint is available
+find . -name "README.md" -type f | xargs markdown-lint
+
+# Visual verification - display first 50 lines of main README
+head -50 README.md
+```
+
+**Git status check:**
+
+```bash
+# If any edits were made, verify they're appropriate
+git status
+git diff README.md
+```
+
+## Notes
+
+### Current State Findings
+
+Based on initial research:
+
+1. **Main README.md**: Currently clean - no archon mentions found
+2. **Git history**: Shows historical commits (fefd8fb, 11a419e, 0828396) that added "hello from archon" but this has been removed
+3. **Code files**: No archon mentions in Python code files
+4. **Branch names**: Some remote branches contain "archon" in their names:
+   - `remotes/origin/add-archon-greeting`
+   - `remotes/origin/archon-greeting`
+   - `remotes/origin/archon-readme-update`
+
+### Scope Clarification
+
+This task focuses on **documentation content** only:
+- README files
+- Markdown documentation
+- User-facing documentation
+
+Out of scope:
+- Git history (cannot be rewritten for distributed repositories)
+- Remote branch names (can be deleted but may not be necessary)
+- Commit messages (immutable without history rewrite)
+
+### Future Considerations
+
+- If branch cleanup is desired, the remote archon-related branches can be deleted with: `git push origin --delete <branch-name>`
+- Consider adding a pre-commit hook or CI check to prevent test content from being committed to documentation
+- Document this cleanup in CHANGELOG if appropriate for project history


### PR DESCRIPTION
## Summary

Remove all mentions of "archon" and "archin" from the project README and documentation files to maintain clean, focused project documentation. This is a documentation cleanup task to ensure no legacy or test content remains in production documentation.

## Problem Statement

Historical commits show that test content mentioning "archon" was previously added to the README (commit fefd8fb: "hello from archon"). While this content appears to have been removed, we need to verify complete removal across all documentation files and ensure no similar mentions exist in other README files throughout the project.

## Changes

- docs: add prp for removing archon mentions from documentation

### Files Modified

- PRPs/features/completed/remove-archon-mentions.md

## Implementation Details

See: `PRPs/features/completed/remove-archon-mentions.md`

This PRP provides a comprehensive plan for:
1. Searching all documentation files for case-insensitive matches
2. Verifying the main README.md is clean
3. Checking all subdirectory README files (14 files identified)
4. Documenting findings and confirming complete removal
5. Providing validation commands to ensure no mentions remain

### Key Findings

- Main README.md currently contains **no mentions** of "archon" or "archin"
- Historical commits show test content was added but subsequently removed
- This task is primarily a verification and documentation cleanup task
- Scope includes documentation only (excludes git history and branch names)

## Testing

- [x] PRP file created with comprehensive validation commands
- [x] Implementation plan with step-by-step tasks
- [x] Acceptance criteria defined
- [ ] Execute validation commands to verify complete removal (pending)
- [ ] Manual verification of all 14 subdirectory README files (pending)

## Validation Commands

The PRP includes comprehensive validation commands to verify complete removal:

```bash
# Search all README files with word boundaries
grep -i "\barchon\b\|\barchin\b" README.md */README.md */*/README.md

# Search all tracked files
git grep -i "\barchon\b\|\barchin\b" -- '*.md' '*.py' '*.txt'

# Verify main README specifically
grep -i "archon|archin" README.md
```